### PR TITLE
upgrade the API from v2.0 to v3.0

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -4,7 +4,7 @@
 #' @noRd
 get_coords_query_uri <- function(location) {
   paste0(
-    "http://api.map.baidu.com/geocoder/v2/?address=", 
+    "http://api.map.baidu.com/geocoding/v3/?address=", 
     location, 
     "&output=json&ak=", 
     "%s"
@@ -17,12 +17,12 @@ get_coords_query_uri <- function(location) {
 #' @noRd
 get_addr_query_uri <- function(lon, lat) {
   paste0(
-    "http://api.map.baidu.com/geocoder/v2/?ak=", 
+    "http://api.map.baidu.com/reverse_geocoding/v3/?ak=", 
      "%s", 
      "&location=", 
      lat, 
      ",", 
      lon, 
-     "&output=json&pois=0"
+     "&output=json&coordtype=wgs84ll"
   )
 }


### PR DESCRIPTION
The Baidu Maps API geocoding services and reverse geocoding has been upgraded from v2 to v3. The v2.0 API is unavailable for users who registered after 2019.06.18. To guarantee the experience and availability, I highly recommend upgrading the API in **baidugeo** synchronously.